### PR TITLE
Add daily build trigger to Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,10 @@ pipeline {
   parameters {
     string(name: 'CONJUR_VERSION', defaultValue: 'latest', description: 'Version of Conjur to build into AMI (e.g. 5.x.x)')
   }
+  
+  triggers {
+    cron(getDailyCronString())
+  }
 
   stages {
     stage('Validate') {


### PR DESCRIPTION
This repo appears to have been failing for a while, and we've not been seeing the notifications because it is not set up for daily builds.

I haven't worked in this repo before - so if it's not set up to only publish new artifacts on git tags, this PR should be rejected until that change is implemented.