### PR TITLE
Add PUBLISH_ARTIFACTS parameter to pipeline builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
 
   parameters {
     string(name: 'CONJUR_VERSION', defaultValue: 'latest', description: 'Version of Conjur to build into AMI (e.g. 5.x.x)')
+    booleanParam(name: 'PUBLISH_ARTIFACTS', description: 'Whether or not to publish AMIs and CFTs', defaultValue: false)
   }
   
   triggers {
@@ -56,6 +57,7 @@ pipeline {
     stage('Promote AMI to other regions') {
       when {
         branch 'master'
+        expression { return params.PUBLISH_ARTIFACTS }
       }
       steps {
         sh './promote-to-regions.sh $(cat AMI.txt)'
@@ -69,6 +71,7 @@ pipeline {
     stage('Publish CFT') {
       when {
         branch 'master'
+        expression { return params.PUBLISH_ARTIFACTS }
       }
       steps {
         sh "summon ./publish-cft.sh ${params.CONJUR_VERSION}"


### PR DESCRIPTION
We just turned on daily master builds for this project, but we don't want every
master build to publish new artifacts. To ensure this only happens when we
intend for it to, we have added a build parameter that is by default false but
can be turned on when we need to publish new AMIs / CFTs.